### PR TITLE
ci: added new workflows

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,51 @@
+name: promote-developpement-to-prod
+
+on:
+  workflow_call:
+    inputs:
+      versionType:
+        type: string
+        description: 'Version type to bump'
+        required: true
+      branch:
+        type: string
+        description: 'Branch to checkout'
+        required: true
+    outputs:
+      version:
+        description: 'Version number'
+        value: ${{ jobs.next_version.outputs.version }}
+
+env:
+  node-version: 22.x
+  branch: developpement
+
+jobs:
+  next_version:
+    name: Get next version
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # important for git log
+          ref: ${{ inputs.branch }} # checkout the branch that triggered the workflow
+
+      - name: Get next version
+        id: get_version
+        run: |
+          version=$(npm version --no-git-tag-version --force --tag-version-prefix='' --ignore-scripts patch)
+          echo "next_version=$version" >> "$GITHUB_OUTPUT"
+          echo "Version number will be $version"
+
+      - name: push version
+        run: |
+          git config --global user.name gitHub-actions
+          git config --global user.email "github-actions@github.com"
+          git add package.json package-lock.json
+          git commit -m "Bump version to ${{ steps.get_version.outputs.version }}"
+          git push origin ${{ inputs.branch }}

--- a/.github/workflows/promote-developpemen-prod.yml
+++ b/.github/workflows/promote-developpemen-prod.yml
@@ -1,0 +1,52 @@
+name: promote-developpement-to-prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionType:
+        type: choice
+        description: 'Version type to bump'
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+        required: true
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Bump version
+        id: bump-version
+        uses: ./.github/workflows/bump_version.yml
+        with:
+          versionType: ${{ github.event.inputs.versionType }}
+          branch: developpement # checkout the developpement branch
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # important for git log
+          ref: developpement # checkout the developpement branch
+
+      - name: Create Release
+        run: |
+          git config --global user.name gitHub-actions
+          git config --global user.email "github-actions@github.com"
+          git checkout -b release-${{ steps.bump-version.outputs.version }}
+          git push origin release-${{ steps.bump-version.outputs.version }}
+          git tag -a v${{ steps.bump-version.outputs.version }} -m "Release v${{ steps.bump-version.outputs.version }}"
+          git push origin v${{ steps.bump-version.outputs.version }}
+
+      - name: Merge to production
+        run: |
+          git config --global user.name gitHub-actions
+          git config --global user.email "github-actions@github.com"
+          git config --global pull.ff only
+          git checkout production
+          git pull
+          git merge --no-ff release-${{ github.event.inputs.versionType }}-${{ steps.bump-version.outputs.version }}
+          git push origin production

--- a/.github/workflows/promote-developpemen-prod.yml
+++ b/.github/workflows/promote-developpemen-prod.yml
@@ -48,5 +48,5 @@ jobs:
           git config --global pull.ff only
           git checkout production
           git pull
-          git merge --no-ff release-${{ github.event.inputs.versionType }}-${{ steps.bump-version.outputs.version }}
+          git merge --no-ff release-${{ steps.bump-version.outputs.version }}
           git push origin production

--- a/.github/workflows/release-developpement.yml
+++ b/.github/workflows/release-developpement.yml
@@ -1,0 +1,40 @@
+name: Merge Develop to Release-Developpement
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # Every day at 5am UTC (adjust if needed)
+
+  workflow_dispatch: # Allows manual triggering too
+
+jobs:
+  bump-version:
+    uses: ./.github/workflows/bump_version.yml
+    with:
+      versionType: ${{ github.event.inputs.versionType || 'patch' }}
+      branch: developpement # checkout the developpement branch
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: bump-version
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # important for git log
+          ref: developpement # checkout the developpement branch
+
+      - name: Set up Git identity
+        run: |
+          git config --global user.name gitHub-actions
+          git config --global user.email "github-actions@github.com"
+          git config --global pull.ff only
+
+      - name: delete release-developpement branch
+        run: |
+          git branch -D release-developpement || true # Ignore error if branch doesn't exist
+
+      - name: Create release-developpement branch
+        run: |
+          git checkout -b release-developpement
+          git push origin release-developpement


### PR DESCRIPTION
This pull request introduces three new GitHub Actions workflows to automate version bumping, release creation, and branch management for the `developpement` branch. These workflows streamline the development-to-production pipeline by automating repetitive tasks such as versioning, tagging, and merging.

### New Workflows for CI/CD Automation:

#### 1. Version Bumping Workflow
* Added a reusable workflow (`bump_version.yml`) to automate version bumps. It accepts inputs for `versionType` (e.g., patch, minor, major) and the target `branch`, calculates the next version, updates `package.json` and `package-lock.json`, and pushes the changes.

#### 2. Promotion to Production Workflow
* Created a workflow (`promote-developpemen-prod.yml`) triggered manually via `workflow_dispatch`. It uses the `bump_version.yml` workflow to bump the version, creates a release branch, tags the release, and merges it into the `production` branch.

#### 3. Daily Merge Workflow
* Added a scheduled workflow (`release-developpement.yml`) to merge the `developpement` branch into a `release-developpement` branch daily at 5 AM UTC. It also allows manual triggering and includes steps to clean up and recreate the `release-developpement` branch.