### PR TITLE
fix: fix necessary rights to push to non-locked branch

### DIFF
--- a/.github/workflows/_enable_protection.yml
+++ b/.github/workflows/_enable_protection.yml
@@ -37,7 +37,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/branches/${{ inputs.branch || github.ref }}/protection \
-            -d '{"required_status_checks":{"strict":true,"contexts":[]},"enforce_admins":true,"required_pull_request_reviews":{"dismissal_restrictions":{"users":[],"teams":["admin"]},"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1,"require_last_push_approval":false,"bypass_pull_request_allowances":{"users":[],"teams":["admin"]}},"restrictions":{"users":[],"teams":[],"apps":[]},"required_linear_history":true,"allow_force_pushes":false,"allow_deletions":false,"block_creations":true,"required_conversation_resolution":true,"lock_branch":${{inputs.lock}},"allow_fork_syncing":false}'
+            -d '{"required_status_checks":{"strict":true,"contexts":[]},"enforce_admins":true,"required_pull_request_reviews":{"dismissal_restrictions":{"users":[],"teams":["admin"]},"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1,"require_last_push_approval":false,"bypass_pull_request_allowances":{"users":[],"teams":["admin"]}},"restrictions":{"users":[],"teams":[],"apps":[]},"required_linear_history":true,"allow_force_pushes":false,"allow_deletions":false,"block_creations":${{inputs.lock}},"required_conversation_resolution":true,"lock_branch":${{inputs.lock}},"allow_fork_syncing":false}'
 
       - name: Allow admins to bypass branch protection rules
         if: ${{ !inputs.lock }}


### PR DESCRIPTION
This pull request modifies the branch protection rules in the GitHub Actions workflow to make the `block_creations` property configurable based on the `inputs.lock` parameter.

### Updates to branch protection rules:

* [`.github/workflows/_enable_protection.yml`](diffhunk://#diff-506abcb5581eebac72454054960a839b21698bd57b3a704242379b6e6827704bL40-R40): Changed the `block_creations` property in the branch protection API payload to dynamically use the `inputs.lock` parameter, aligning it with the existing `lock_branch` configuration.